### PR TITLE
feat(upload): vollständige Überarbeitung des Dokument-Uploads

### DIFF
--- a/pathfinder-backend/src/main/java/com/pathfinder/controller/MeinKontoDocumentsController.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/controller/MeinKontoDocumentsController.java
@@ -1,11 +1,12 @@
 package com.pathfinder.controller;
 
 import com.pathfinder.dto.DocumentListResponseDTO;
+import com.pathfinder.dto.DocumentMapper;
 import com.pathfinder.dto.DocumentResponseDTO;
 import com.pathfinder.dto.DocumentUploadResponseDTO;
-import com.pathfinder.dto.DocumentMapper;
 import com.pathfinder.model.NachwuchskraftAnhang;
 import com.pathfinder.service.NachwuchskraftAnhangService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,8 +30,9 @@ public class MeinKontoDocumentsController {
     public ResponseEntity<DocumentListResponseDTO> getDocuments(@PathVariable Long nwkId) {
         List<NachwuchskraftAnhang> docs = service.getByNachwuchskraft(nwkId);
 
-        if (docs.isEmpty())
+        if (docs.isEmpty()) {
             return ResponseEntity.noContent().build();
+        }
 
         List<DocumentResponseDTO> dtos = docs.stream()
                 .map(DocumentMapper::toDTO)
@@ -40,23 +42,25 @@ public class MeinKontoDocumentsController {
     }
 
     // POST (Upload)
-    @PostMapping(consumes = "multipart/form-data")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<DocumentUploadResponseDTO> uploadDocument(
             @RequestParam("file") MultipartFile file,
             @RequestParam("nwkId") Long nwkId,
             @RequestParam("typ") NachwuchskraftAnhang.DokumentTyp typ
     ) throws IOException {
+
         NachwuchskraftAnhang saved = service.storeFile(file, nwkId, typ);
         return ResponseEntity.ok(DocumentMapper.toUploadDTO(saved));
     }
 
     // PUT (Update)
-    @PutMapping(value = "/{id}", consumes = "multipart/form-data")
+    @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<DocumentUploadResponseDTO> updateDocument(
             @PathVariable Long id,
             @RequestParam("file") MultipartFile file,
             @RequestParam("typ") NachwuchskraftAnhang.DokumentTyp typ
     ) throws IOException {
+
         NachwuchskraftAnhang saved = service.updateFile(id, file, typ);
         return ResponseEntity.ok(DocumentMapper.toUploadDTO(saved));
     }

--- a/pathfinder-backend/src/main/java/com/pathfinder/dto/DocumentMapper.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/dto/DocumentMapper.java
@@ -1,7 +1,5 @@
 package com.pathfinder.dto;
 
-import com.pathfinder.dto.DocumentResponseDTO;
-import com.pathfinder.dto.DocumentUploadResponseDTO;
 import com.pathfinder.model.NachwuchskraftAnhang;
 
 public class DocumentMapper {

--- a/pathfinder-backend/src/main/java/com/pathfinder/exception/FileTooLargeException.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/exception/FileTooLargeException.java
@@ -1,6 +1,11 @@
 package com.pathfinder.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
 public class FileTooLargeException extends RuntimeException {
+
     public FileTooLargeException(String message) {
         super(message);
     }

--- a/pathfinder-backend/src/main/java/com/pathfinder/exception/InvalidFileTypeException.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/exception/InvalidFileTypeException.java
@@ -1,6 +1,11 @@
 package com.pathfinder.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class InvalidFileTypeException extends RuntimeException {
+
     public InvalidFileTypeException(String message) {
         super(message);
     }

--- a/pathfinder-backend/src/main/java/com/pathfinder/exception/NachwuchskraftNotFoundException.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/exception/NachwuchskraftNotFoundException.java
@@ -1,7 +1,12 @@
 package com.pathfinder.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NachwuchskraftNotFoundException extends RuntimeException {
+
     public NachwuchskraftNotFoundException(Long id) {
-        super("Nachwuchskraft mit ID " + id + " wurde nicht gefunden");
+        super("Nachwuchskraft mit ID " + id + " wurde nicht gefunden.");
     }
 }

--- a/pathfinder-backend/src/main/java/com/pathfinder/model/Nachwuchskraft.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/model/Nachwuchskraft.java
@@ -33,14 +33,13 @@ public class Nachwuchskraft {
     @Column(name = "STUDIENRICHTUNG")
     private String studienrichtung;
 
-    // neu: Jahrgang als String, z.B. "2023/2026"
     @Column(name = "JAHRGANG", nullable = false, length = 20)
     private String jahrgang;
 
     @Column(name = "ERSTELLT_AM")
     private LocalDateTime erstelltAm = LocalDateTime.now();
 
-    // vom Nachwuchskraft selbst bearbeitbar
+    // Interessen (Tags)
     @ManyToMany
     @JoinTable(
             name = "nachwuchskraft_interesse",
@@ -49,9 +48,7 @@ public class Nachwuchskraft {
     )
     private List<Tag> interessen = new ArrayList<>();
 
-    // umbenannt: Erfahrungen -> Praktika
-    // nicht mehr über /meinKonto von NWK bearbeitbar
-    // absolvierte Praktika (n:m)
+    // Absolvierte Praktika
     @ManyToMany
     @JoinTable(
             name = "nachwuchskraft_praktikum",
@@ -60,18 +57,17 @@ public class Nachwuchskraft {
     )
     private List<Abteilung> praktika = new ArrayList<>();
 
-
-    // Beziehung zu Anhaenge (1:n)
+    // Anhänge 1:n
     @OneToMany(mappedBy = "nachwuchskraft", cascade = CascadeType.ALL, orphanRemoval = true)
-    @JsonManagedReference
+    @JsonManagedReference(value = "anhang-nwk")
     private List<NachwuchskraftAnhang> anhaenge = new ArrayList<>();
 
-    // Beziehung zu Bewerbung (1:n)
+    // Bewerbungen 1:n
     @OneToMany(mappedBy = "nachwuchskraft", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference("bewerbung-nwk")
     private List<Bewerbung> bewerbungen = new ArrayList<>();
 
-    // Wunschabteilungen (n:m)
+    // Wunschabteilungen
     @ManyToMany
     @JoinTable(
             name = "wunschabteilung",

--- a/pathfinder-backend/src/main/java/com/pathfinder/model/NachwuchskraftAnhang.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/model/NachwuchskraftAnhang.java
@@ -3,6 +3,7 @@ package com.pathfinder.model;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.Data;
+
 import java.time.LocalDateTime;
 
 @Data
@@ -14,16 +15,21 @@ public class NachwuchskraftAnhang {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    // Viele Anhänge gehören zu einer Nachwuchskraft
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "nachwuchskraft_id", nullable = false)
-    @JsonBackReference
+    @JsonBackReference(value = "anhang-nwk")
     private Nachwuchskraft nachwuchskraft;
 
+    // Relativer Pfad ab dem konfigurierten Upload-Root
+    @Column(name = "DATEIPFAD", nullable = false, length = 500)
     private String dateipfad;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "TYP", nullable = false, length = 50)
     private DokumentTyp typ;
 
+    @Column(name = "HOCHGELADEN_AM", nullable = false)
     private LocalDateTime hochgeladenAm = LocalDateTime.now();
 
     public enum DokumentTyp {

--- a/pathfinder-backend/src/main/java/com/pathfinder/repository/NachwuchskraftAnhangRepository.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/repository/NachwuchskraftAnhangRepository.java
@@ -2,8 +2,10 @@ package com.pathfinder.repository;
 
 import com.pathfinder.model.NachwuchskraftAnhang;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 
 public interface NachwuchskraftAnhangRepository extends JpaRepository<NachwuchskraftAnhang, Long> {
+
     List<NachwuchskraftAnhang> findByNachwuchskraftId(Long nwkId);
 }

--- a/pathfinder-backend/src/main/java/com/pathfinder/service/NachwuchskraftAnhangService.java
+++ b/pathfinder-backend/src/main/java/com/pathfinder/service/NachwuchskraftAnhangService.java
@@ -2,10 +2,12 @@ package com.pathfinder.service;
 
 import com.pathfinder.exception.FileTooLargeException;
 import com.pathfinder.exception.InvalidFileTypeException;
+import com.pathfinder.exception.NachwuchskraftNotFoundException;
 import com.pathfinder.model.Nachwuchskraft;
 import com.pathfinder.model.NachwuchskraftAnhang;
 import com.pathfinder.repository.NachwuchskraftAnhangRepository;
 import com.pathfinder.repository.NachwuchskraftRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -19,11 +21,14 @@ public class NachwuchskraftAnhangService {
 
     private final NachwuchskraftAnhangRepository repository;
     private final NachwuchskraftRepository nwkRepository;
+    private final Path rootDir;
 
     public NachwuchskraftAnhangService(NachwuchskraftAnhangRepository repository,
-                                       NachwuchskraftRepository nwkRepository) {
+                                       NachwuchskraftRepository nwkRepository,
+                                       @Value("${pathfinder.upload-dir:uploads}") String uploadDir) {
         this.repository = repository;
         this.nwkRepository = nwkRepository;
+        this.rootDir = Paths.get(uploadDir).toAbsolutePath().normalize();
     }
 
     public List<NachwuchskraftAnhang> getByNachwuchskraft(Long id) {
@@ -35,23 +40,38 @@ public class NachwuchskraftAnhangService {
                                           NachwuchskraftAnhang.DokumentTyp typ)
             throws IOException {
 
-        Nachwuchskraft nwk = nwkRepository.findById(nwkId).orElseThrow();
+        if (file == null || file.isEmpty()) {
+            throw new InvalidFileTypeException("Leere Datei kann nicht hochgeladen werden.");
+        }
+
+        Nachwuchskraft nwk = nwkRepository.findById(nwkId)
+                .orElseThrow(() -> new NachwuchskraftNotFoundException(nwkId));
 
         validateFileType(file);
         validateFileSize(file);
 
-        Path uploadDir = Paths.get("uploads/documents/" + nwkId);
+        // Unterordner: documents/{nwkId}
+        Path uploadDir = rootDir.resolve("documents").resolve(nwkId.toString());
         Files.createDirectories(uploadDir);
 
-        String filename = System.currentTimeMillis() + "_" + file.getOriginalFilename();
-        Path filePath = uploadDir.resolve(filename);
+        String originalName = file.getOriginalFilename() != null
+                ? file.getOriginalFilename()
+                : "upload.bin";
 
-        Files.write(filePath, file.getBytes(), StandardOpenOption.CREATE_NEW);
+        String filename = System.currentTimeMillis() + "_" + originalName;
+
+        Path target = uploadDir.resolve(filename);
+
+        // Physisch speichern
+        Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+
+        // relativer Pfad ab rootDir
+        String relativePath = rootDir.relativize(target).toString().replace("\\", "/");
 
         NachwuchskraftAnhang anhang = new NachwuchskraftAnhang();
         anhang.setNachwuchskraft(nwk);
         anhang.setTyp(typ);
-        anhang.setDateipfad(filePath.toString());
+        anhang.setDateipfad(relativePath);
         anhang.setHochgeladenAm(LocalDateTime.now());
 
         return repository.save(anhang);
@@ -62,54 +82,77 @@ public class NachwuchskraftAnhangService {
                                            NachwuchskraftAnhang.DokumentTyp typ)
             throws IOException {
 
-        NachwuchskraftAnhang existing = repository.findById(id).orElseThrow();
-
-        Path oldPath = Paths.get(existing.getDateipfad());
-        if (Files.exists(oldPath)) {
-            Files.delete(oldPath);
+        if (file == null || file.isEmpty()) {
+            throw new InvalidFileTypeException("Leere Datei kann nicht hochgeladen werden.");
         }
+
+        NachwuchskraftAnhang existing = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Anhang mit ID " + id + " nicht gefunden."));
 
         validateFileType(file);
         validateFileSize(file);
 
-        Path uploadDir = Paths.get("uploads/documents/" + existing.getNachwuchskraft().getId());
+        if (existing.getDateipfad() != null) {
+            Path oldPath = rootDir.resolve(existing.getDateipfad()).normalize();
+            if (Files.exists(oldPath)) {
+                Files.delete(oldPath);
+            }
+        }
+
+        Long nwkId = existing.getNachwuchskraft().getId();
+        Path uploadDir = rootDir.resolve("documents").resolve(nwkId.toString());
         Files.createDirectories(uploadDir);
 
-        String filename = System.currentTimeMillis() + "_" + file.getOriginalFilename();
-        Path filePath = uploadDir.resolve(filename);
+        String originalName = file.getOriginalFilename() != null
+                ? file.getOriginalFilename()
+                : "upload.bin";
 
-        Files.write(filePath, file.getBytes(), StandardOpenOption.CREATE_NEW);
+        String filename = System.currentTimeMillis() + "_" + originalName;
+
+        Path target = uploadDir.resolve(filename);
+        Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+
+        String relativePath = rootDir.relativize(target).toString().replace("\\", "/");
 
         existing.setTyp(typ);
-        existing.setDateipfad(filePath.toString());
+        existing.setDateipfad(relativePath);
         existing.setHochgeladenAm(LocalDateTime.now());
 
         return repository.save(existing);
     }
 
     public void delete(Long id) {
-        NachwuchskraftAnhang existing = repository.findById(id).orElseThrow();
-        Path filePath = Paths.get(existing.getDateipfad());
+        NachwuchskraftAnhang existing = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Anhang mit ID " + id + " nicht gefunden."));
 
-        if (Files.exists(filePath)) {
-            try {
-                Files.delete(filePath);
-            } catch (IOException ignored) {}
+        if (existing.getDateipfad() != null) {
+            Path filePath = rootDir.resolve(existing.getDateipfad()).normalize();
+            if (Files.exists(filePath)) {
+                try {
+                    Files.delete(filePath);
+                } catch (IOException ignored) {
+                }
+            }
         }
 
         repository.deleteById(id);
     }
 
     private void validateFileType(MultipartFile file) {
-        String name = file.getOriginalFilename().toLowerCase();
+        String name = file.getOriginalFilename();
+        if (name == null) {
+            throw new InvalidFileTypeException("Dateiname fehlt.");
+        }
 
-        if (!(name.endsWith(".pdf") || name.endsWith(".docx") || name.endsWith(".doc"))) {
-            throw new InvalidFileTypeException("Ungültiges Dateiformat. Erlaubt sind nur PDF oder DOCX.");
+        String lower = name.toLowerCase();
+
+        if (!(lower.endsWith(".pdf") || lower.endsWith(".docx") || lower.endsWith(".doc"))) {
+            throw new InvalidFileTypeException("Ungültiges Dateiformat. Erlaubt sind nur PDF oder DOC/DOCX.");
         }
     }
 
     private void validateFileSize(MultipartFile file) {
-        long maxBytes = 10 * 1024 * 1024;
+        long maxBytes = 10 * 1024 * 1024; // 10 MB
 
         if (file.getSize() > maxBytes) {
             throw new FileTooLargeException("Die Datei ist zu groß. Maximal erlaubt sind 10 MB.");

--- a/pathfinder-backend/src/main/resources/application.properties
+++ b/pathfinder-backend/src/main/resources/application.properties
@@ -17,6 +17,6 @@ spring.jpa.defer-datasource-initialization=true
 spring.security.user.name=admin
 spring.security.user.password=password
 
-spring.servlet.multipart.max-file-size=10KB
-spring.servlet.multipart.max-request-size=10KB
-
+pathfinder.upload-dir=C:/pathfinder/uploads
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
- konfigurierbares Upload-Verzeichnis über pathfinder.upload-dir hinzugefügt
- gesamte Datei-Verarbeitung gefixt
- relative Speicherpfade eingeführt (documents/{nwkId}/…)
- Files.write durch Files.copy ersetzt
- automatische Ordnererstellung pro Nachwuchskraft
- Validierung für Dateityp, Dateigröße und leere Dateien ergänzt
- DocumentMapper vereinfacht und vereinheitlicht
- Entities für Nachwuchskraft und Anhang überarbeitet (Mapping, Referenzen)
- Repository für Anhänge bereinigt und konsistent verwendet